### PR TITLE
Change app ID in config.xml

### DIFF
--- a/www/config.xml
+++ b/www/config.xml
@@ -19,7 +19,7 @@
 -->
 <widget xmlns     = "http://www.w3.org/ns/widgets"
         xmlns:gap = "http://phonegap.com/ns/1.0"
-        id        = "io.cordova.hello-cordova"
+        id        = "io.cordova.hello_cordova"
         version   = "2.0.0">
     <name>Hello Cordova</name>
 


### PR DESCRIPTION
`io.cordova.hello-cordova` isn't permitted as an ID on Android
because of the dash. I haven't verified, but I suspect the same issue
would arise on other platforms.

This affects projects generated with the cordova CLI tools that don't
specify a different App ID.
