### PR TITLE
Added CORS header

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,7 +5,9 @@ var formidable = require('formidable'),
     stringify = require('json-stringify-safe');
 
 http.createServer(function (req, res) {
-	
+    // Set CORS headers
+    res.setHeader('Access-Control-Allow-Origin', '*');
+
 	var basic_auth_username = "cordova_user";
 	var basic_auth_password = "cordova_password";
 	


### PR DESCRIPTION
Needed to avoid 
```
org.apache.cordova.mobilespec.tests.localXHR.tests >> XMLHttpRequest
XMLHttpRequest.spec.9 calls onload from successful http get Expected 
spy onError not to have been called.
```
in hosted `mobilespec`.