### PR TITLE
CB-9840 Fallback file-transfer uploadResponse encoding to latin1 in c…

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "node": ">=0.10.0"
   },
   "dependencies": {
-    "json-stringify-safe": "5.0.0",
-    "formidable": "1.0.x"
+    "formidable": "1.0.x",
+    "iconv": "2.1.x",
+    "json-stringify-safe": "5.0.0"
   }
 }


### PR DESCRIPTION
…ase not encoded with UTF-8 on iOS

Adds non-utf endpoints for the correspoding tests: [filetransfer.spec.36](https://github.com/apache/cordova-plugin-file-transfer/blob/866349eb849e6260755d587066850c783d6bdb05/tests/tests.js#L739) and [37](https://github.com/apache/cordova-plugin-file-transfer/blob/866349eb849e6260755d587066850c783d6bdb05/tests/tests.js#L1119). 
Implemented using [node-iconv](https://github.com/bnoordhuis/node-iconv).

[Jira issue](https://issues.apache.org/jira/browse/CB-9840)

Corresponding file-transfer PR: https://github.com/apache/cordova-plugin-file-transfer/pull/71